### PR TITLE
make the `supercharged` package note bigger

### DIFF
--- a/example/example.md
+++ b/example/example.md
@@ -1,7 +1,7 @@
 
 # 📝 Examples
 
-🛈 *Note: These examples uses **[supercharged](https://pub.dev/packages/supercharged)** for syntactic sugar.*
+## *Note: These examples uses **[supercharged](https://pub.dev/packages/supercharged)** for syntactic sugar.*
 
 ## Simple PlayAnimation widget
 


### PR DESCRIPTION
When using the plugin, I noticed that the note about `supercharged` package is very small and that cost me 30 minutes of my life.
- The new fix is in `example/example.md`.
Thanx for the amazing package.